### PR TITLE
menu: Namespace mm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The menu has options for:
 Beneath the first 5 items are a list of all hidden windows.
 
 Middle-click anywhere other than the focused window
-to run "mm mouse2".
-It's up to you to write an "mm" program and put it in your path somewhere,
+to run "9wm-mm".
+It's up to you to write an "9wm-mm" program and put it in your path somewhere,
 if you want to use this for something.
 I have mine run "google-chrome-stable --show-app-list".
 

--- a/menu.c
+++ b/menu.c
@@ -64,7 +64,7 @@ button(XButtonEvent * e)
 		if ((e->state & (ShiftMask | ControlMask)) == (ShiftMask | ControlMask)) {
 			menuhit(e, &egg);
 		} else {
-			spawn(s, "mm mouse2");
+			spawn(s, "9wm-mm");
 		}
 		return;
 	default:


### PR DESCRIPTION
I think we should really namespace the mm command.
mm is far to general as a name for a command that is primarily symlinked to something else anyway.
Because of this I also don't see a reason to pass mouse2 as an argument.
However, I'll leave this open for a few weeks in case @nealey has any reasons for this that I haven't considered.
