### PR TITLE
9wm: Ignore SIGCHLD instead of handling it

### DIFF
--- a/9wm.c
+++ b/9wm.c
@@ -70,12 +70,6 @@ char *fontlist[] = {
 };
 
 void
-sigchld(int signum)
-{
-	while (0 < waitpid(-1, NULL, WNOHANG));
-}
-
-void
 usage(void)
 {
 	fprintf(stderr, "usage: 9wm [-version] [-cursor cursor] [-border] [-font fname] [-term prog] [-active color] [-inactive color] [exit|restart]\n");
@@ -176,7 +170,7 @@ main(int argc, char *argv[])
 		signal(SIGINT, SIG_IGN);
 	if (signal(SIGHUP, sighandler) == SIG_IGN)
 		signal(SIGHUP, SIG_IGN);
-	signal(SIGCHLD, sigchld);
+	signal(SIGCHLD, SIG_IGN);
 
 	exit_9wm = XInternAtom(dpy, "9WM_EXIT", False);
 	restart_9wm = XInternAtom(dpy, "9WM_RESTART", False);


### PR DESCRIPTION
This prevents defunct processes from being created.
waitpid within a SIGCHLD handler doesn't do anything, as by the time you get the signal, the process has already exited. 9wm doesn't need to do anything with the process afterwards, so it's safe to just ignore.