### PR TITLE
cleanup compiler issues identified in gcc 15

### DIFF
--- a/9wm.c
+++ b/9wm.c
@@ -382,8 +382,7 @@ sendcmessage(Window w, Atom a, long x, int isroot)
 }
 
 void
-sendconfig(c)
-     Client *c;
+sendconfig(Client *c)
 {
 	XConfigureEvent ce;
 
@@ -401,7 +400,7 @@ sendconfig(c)
 }
 
 void
-sighandler(void)
+sighandler(int)
 {
 	signalled = 1;
 }

--- a/event.c
+++ b/event.c
@@ -452,8 +452,7 @@ reparent(XReparentEvent * e)
 
 #ifdef	SHAPE
 void
-shapenotify(e)
-     XShapeEvent *e;
+shapenotify(XShapeEvent *e)
 {
 	Client *c;
 

--- a/fns.h
+++ b/fns.h
@@ -2,6 +2,9 @@
  * Copyright multiple authors, see README for licence details
  */
 
+/* for XShapeEvent */
+#include <X11/extensions/shape.h>
+
 #ifdef	DEBUG
 #define	trace(s, c, e)	dotrace((s), (c), (e))
 #else
@@ -10,86 +13,88 @@
 
 /* 9wm.c */
 void	usage();
-void	initscreen();
-ScreenInfo *getscreen();
+void	initscreen(ScreenInfo *, int);
+ScreenInfo *getscreen(Window);
 Time	timestamp();
-void	sendcmessage();
-void	sendconfig();
-void	sighandler();
-void	getevent();
+void	sendcmessage(Window, Atom, long, int);
+void	sendconfig(Client *);
+void	sighandler(int);
+void	getevent(XEvent *);
 void	cleanup();
 
 /* event.c */
-void	mainloop();
-void	configurereq();
-void	mapreq();
-void	circulatereq();
-void	unmap();
-void	newwindow();
-void	destroy();
-void	clientmesg();
-void	cmap();
-void	property();
-void	shapenotify();
-void	enter();
-void	focusin();
-void	reparent();
+void	mainloop(int);
+void	configurereq(XConfigureRequestEvent *);
+void	mapreq(XMapRequestEvent *);
+void	circulatereq(XCirculateRequestEvent *);
+void	unmap(XUnmapEvent *);
+void	newwindow(XCreateWindowEvent *);
+void	destroy(Window);
+void	clientmesg(XClientMessageEvent *);
+void	cmap(XColormapEvent *);
+void	property(XPropertyEvent *);
+#ifdef SHAPE
+void	shapenotify(XShapeEvent *);
+#endif
+void	enter(XCrossingEvent *);
+void	focusin(XFocusChangeEvent *);
+void	reparent(XReparentEvent *);
 
 /* manage.c */
-int 	manage();
-void	scanwins();
-void	setshape();
-void	withdraw();
-void	gravitate();
-void	cmapfocus();
-void	cmapnofocus();
-void	getcmaps();
-int 	_getprop();
-char	*getprop();
-Window	getwprop();
-int 	getiprop();
-int 	getwstate();
-void	setwstate();
-void	setlabel();
-void	getproto();
-void	gettrans();
+int 	manage(Client *, int);
+void	scanwins(ScreenInfo *);
+void	setshape(Client *);
+void	withdraw(Client *);
+void	gravitate(Client *, int);
+void	cmapfocus(Client *);
+void	cmapnofocus(ScreenInfo *);
+void	getcmaps(Client *);
+int 	_getprop(Window, Atom, Atom, long, unsigned char **);
+char	*getprop(Window, Atom);
+Window	getwprop(Window, Atom);
+int 	getiprop(Window, Atom);
+int 	getwstate(Window, int *);
+void	setwstate(Client *, int);
+void	setlabel(Client *);
+void	getproto(Client *);
+void	gettrans(Client *);
 
 /* menu.c */
-void	button();
-void	spawn();
-void	reshape();
-void	move();
-void	delete();
-void	hide();
-void	unhide();
-void	unhidec();
-void	renamec();
+void	button(XButtonEvent *);
+void	spawn(ScreenInfo *, char *);
+void	reshape(Client *);
+void	move(Client *);
+void	delete(Client *, int);
+void	hide(Client *);
+void	unhide(int, int);
+void	unhidec(Client *, int);
+void	renamec(Client *, char *);
 
 /* client.c */
-void	setactive();
-void	draw_border();
-void	active();
+void	setactive(Client *, int);
+void	draw_border(Client *, int);
+void	active(Client *);
 void	nofocus();
-void	top();
-Client	*getclient();
-void	rmclient();
+void	top(Client *);
+Client	*getclient(Window, int);
+void	rmclient(Client *);
 void	dump_revert();
 void	dump_clients();
 
 /* grab.c */
-int 	menuhit();
-Client	*selectwin();
-int 	sweep();
-int 	drag();
-void	getmouse();
-void	setmouse();
+int 	menuhit(XButtonEvent *, Menu *);
+Client	*selectwin(int, int *, ScreenInfo *);
+int 	sweep(Client *);
+int 	drag(Client *);
+void	getmouse(int *, int *, ScreenInfo *);
+void	setmouse(int, int, ScreenInfo *);
 
 /* error.c */
-int 	handler();
-void	fatal();
-void	graberror();
+int 	handler(Display *, XErrorEvent *);
+void	fatal(char *);
+void	graberror(char *, int);
 void	showhints();
-void	dotrace();
+void	dotrace(char *, Client *, XEvent *);
 
 /* cursor.c */
 void	initcurs(ScreenInfo * s);

--- a/grab.c
+++ b/grab.c
@@ -303,7 +303,7 @@ misleep(int msec)
 }
 
 int
-sweepdrag(Client * c, XButtonEvent * e0, void (*recalc) ())
+sweepdrag(Client * c, XButtonEvent * e0, void (*recalc) (Client *, int, int))
 {
 	XEvent ev;
 	int idle;

--- a/menu.c
+++ b/menu.c
@@ -124,8 +124,7 @@ spawn(ScreenInfo * s, char *prog)
 }
 
 void
-reshape(c)
-     Client *c;
+reshape(Client *c)
 {
 	int odx, ody;
 
@@ -160,9 +159,7 @@ move(Client * c)
 }
 
 void
-delete(c, shift)
-     Client *c;
-     int shift;
+delete(Client *c, int shift)
 {
 	if (c == 0)
 		return;
@@ -231,9 +228,7 @@ unhide(int n, int map)
 }
 
 void
-unhidec(c, map)
-     Client *c;
-     int map;
+unhidec(Client *c, int map)
 {
 	int i;
 
@@ -246,9 +241,7 @@ unhidec(c, map)
 }
 
 void
-renamec(c, name)
-     Client *c;
-     char *name;
+renamec(Client *c, char *name)
 {
 	int i;
 


### PR DESCRIPTION
In early testing, Fedora's GCC maintainers discovered issues with 9wm. This is because C23 is stricter about function prototypes, among other areas, and 9wm is some older code.

This change updates the function prototypes and eliminates "old style" function definitions. With these changes, 9wm compiles properly with both GCC 14 and 15.